### PR TITLE
Render consent banner always and toggle visibility

### DIFF
--- a/Controller/CookieConsentController.php
+++ b/Controller/CookieConsentController.php
@@ -64,11 +64,7 @@ class CookieConsentController
     #[Route('/cookie_consent_alt', name: 'ch_cookie_consent.show_if_cookie_consent_not_set')]
     public function showIfCookieConsentNotSet(Request $request): Response
     {
-        if ($this->cookieChecker->isCookieConsentSavedByUser() === false) {
-            return $this->show($request);
-        }
-
-        return new Response();
+        return $this->show($request);
     }
 
     /**

--- a/Resources/public/js/cookie_consent.js
+++ b/Resources/public/js/cookie_consent.js
@@ -25,9 +25,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (manageBtn) {
     manageBtn.addEventListener('click', () => {
-      manageBtn.style.display = 'none';
       if (cookieConsent) {
-        cookieConsent.style.display = 'block';
+        const isHidden = cookieConsent.style.display === 'none' || getComputedStyle(cookieConsent).display === 'none';
+        cookieConsent.style.display = isHidden ? 'block' : 'none';
+        manageBtn.style.display = isHidden ? 'none' : 'block';
       }
     });
   }

--- a/Resources/views/cookie_consent.html.twig
+++ b/Resources/views/cookie_consent.html.twig
@@ -4,7 +4,7 @@
     <script src="{{ asset('bundles/chcookieconsent/js/cookie_consent.js') }}"></script>
 {% endblock %}
 
-<div class="ch-cookie-consent ch-cookie-consent--{{ theme }}-theme ch-cookie-consent--{{ position }} {% if simplified %}ch-cookie-consent--simplified{% endif %}">
+<div class="ch-cookie-consent ch-cookie-consent--{{ theme }}-theme ch-cookie-consent--{{ position }} {% if simplified %}ch-cookie-consent--simplified{% endif %}"{% if chcookieconsent_isCookieConsentSavedByUser() %} style="display:none"{% endif %}>
     {% block title %}
         <h3 class="ch-cookie-consent__title">{{ 'ch_cookie_consent.title'|trans({}, 'CHCookieConsentBundle') }}</h3>
     {% endblock %}

--- a/Tests/Controller/CookieConsentControllerTest.php
+++ b/Tests/Controller/CookieConsentControllerTest.php
@@ -93,11 +93,6 @@ class CookieConsentControllerTest extends TestCase
 
     public function testShowIfCookieConsentNotSet(): void
     {
-        $this->cookieChecker
-            ->expects($this->once())
-            ->method('isCookieConsentSavedByUser')
-            ->willReturn(false);
-
         $this->formFactory
             ->expects($this->once())
             ->method('create')
@@ -116,11 +111,6 @@ class CookieConsentControllerTest extends TestCase
 
     public function testShowIfCookieConsentNotSetWithLocale(): void
     {
-        $this->cookieChecker
-            ->expects($this->once())
-            ->method('isCookieConsentSavedByUser')
-            ->willReturn(false);
-
         $this->formFactory
             ->expects($this->once())
             ->method('create')
@@ -158,19 +148,16 @@ class CookieConsentControllerTest extends TestCase
 
     public function testShowIfCookieConsentNotSetWithCookieConsentSet(): void
     {
-        $this->cookieChecker
-            ->expects($this->once())
-            ->method('isCookieConsentSavedByUser')
-            ->willReturn(true);
-
         $this->formFactory
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('create')
-            ->with(CookieConsentType::class);
+            ->with(CookieConsentType::class)
+            ->willReturn($this->createMock(FormInterface::class));
 
         $this->templating
-            ->expects($this->never())
-            ->method('render');
+            ->expects($this->once())
+            ->method('render')
+            ->willReturn('test');
 
         $response = $this->cookieConsentController->showIfCookieConsentNotSet(new Request());
 


### PR DESCRIPTION
## Summary
- always render cookie consent template
- hide banner when consent already saved
- toggle visibility from JS manage button
- update controller tests for new behaviour

## Testing
- `composer install` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855142f343c832a81f231abfd447f94