### PR TITLE
Implement checkbox switch for cookie categories

### DIFF
--- a/Form/CookieConsentType.php
+++ b/Form/CookieConsentType.php
@@ -11,7 +11,7 @@ namespace ConnectHolland\CookieConsentBundle\Form;
 
 use ConnectHolland\CookieConsentBundle\Cookie\CookieChecker;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -40,16 +40,25 @@ class CookieConsentType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         foreach ($this->cookieCategories as $category) {
-            $builder->add($category, ChoiceType::class, [
-                'expanded' => true,
-                'multiple' => false,
-                'data'     => $this->cookieChecker->isCategoryAllowedByUser($category) ? 'true' : 'false',
-                'choices'  => [
-                    ['ch_cookie_consent.yes' => 'true'],
-                    ['ch_cookie_consent.no' => 'false'],
-                ],
+            $builder->add($category, CheckboxType::class, [
+                'required'  => false,
+                'data'      => $this->cookieChecker->isCookieConsentSavedByUser()
+                    ? $this->cookieChecker->isCategoryAllowedByUser($category)
+                    : true,
+                'label_attr' => ['class' => 'checkbox-switch'],
+                'attr'       => ['class' => 'form-check-input'],
             ]);
         }
+
+        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event): void {
+            $data = $event->getData();
+
+            foreach ($this->cookieCategories as $category) {
+                $data[$category] = ($data[$category] ?? false) ? 'true' : 'false';
+            }
+
+            $event->setData($data);
+        });
 
         if ($this->cookieConsentSimplified === false) {
             $builder->add('save', SubmitType::class, ['label' => 'ch_cookie_consent.save', 'attr' => ['class' => 'btn ch-cookie-consent__btn']]);

--- a/Resources/public/css/cookie_consent.css
+++ b/Resources/public/css/cookie_consent.css
@@ -46,10 +46,8 @@
 }
 
 .ch-cookie-consent__category-toggle {
-  display: -ms-flexbox;
   display: flex;
-  -ms-flex-align: start;
-  align-items: flex-start;
+  align-items: center;
 }
 
 @media screen and (max-width: 641px) {
@@ -59,40 +57,39 @@
 }
 
 .ch-cookie-consent__category-toggle input {
-  opacity: 0;
-  position: absolute;
-  left: -10000px;
+  margin-right: 0.5rem;
+  position: relative;
+  width: 2.25rem;
+  height: 1.25rem;
+  appearance: none;
+  background-color: #adb5bd;
+  border-radius: 1.25rem;
+  transition: background-color 0.2s;
 }
 
-.ch-cookie-consent__category-toggle input + label {
-  background-repeat: no-repeat;
-  background-position: 45px center;
-  background-color: #fff;
-  color: #223462;
-  border: 1px solid #223462;
-  transition: all 0.2s;
-  display: inline-block;
-  margin-right: 15px;
-  padding: 6px 28px 6px 10px;
-  cursor: pointer;
-  border-radius: 6px;
-  width: 75px;
-}
-
-.ch-cookie-consent__category-toggle input + label::before,
-.ch-cookie-consent__category-toggle input + label::after {
+.ch-cookie-consent__category-toggle input::before {
   content: "";
+  position: absolute;
+  top: 0.125rem;
+  left: 0.125rem;
+  width: 1rem;
+  height: 1rem;
+  background-color: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
 }
 
-.ch-cookie-consent__category-toggle input:checked + label,
-.ch-cookie-consent__category-toggle input + label:hover {
+.ch-cookie-consent__category-toggle input:checked {
   background-color: #223462;
-  color: #fff;
-  border-color: #fff;
 }
 
-.ch-cookie-consent__category-toggle input:checked + label {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath fill='#fff' d='M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z'/%3E%3C/svg%3E");
+.ch-cookie-consent__category-toggle input:checked::before {
+  transform: translateX(1rem);
+}
+
+.checkbox-switch {
+  margin: 0;
+  cursor: pointer;
 }
 
 .ch-cookie-consent__category-title {
@@ -185,21 +182,20 @@
   border-color: #fff;
 }
 
-.ch-cookie-consent--dark-theme .ch-cookie-consent__category-toggle input + label {
-  background-color: #000;
-  color: #fff;
-  border-color: #fff;
+.ch-cookie-consent--dark-theme .ch-cookie-consent__category-toggle input {
+  background-color: #6c757d;
 }
 
-.ch-cookie-consent--dark-theme .ch-cookie-consent__category-toggle input:checked + label,
-.ch-cookie-consent--dark-theme .ch-cookie-consent__category-toggle input + label:hover {
+.ch-cookie-consent--dark-theme .ch-cookie-consent__category-toggle input:checked {
   background-color: #fff;
-  color: #000;
-  border-color: #000;
 }
 
-.ch-cookie-consent--dark-theme .ch-cookie-consent__category-toggle input:checked + label {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath fill='#000' d='M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z'/%3E%3C/svg%3E");
+.ch-cookie-consent--dark-theme .ch-cookie-consent__category-toggle input:checked::before {
+  background-color: #000;
+}
+
+.ch-cookie-consent--dark-theme .checkbox-switch {
+  color: #fff;
 }
 
 .ch-cookie-consent--dark-theme .ch-cookie-consent__category-title {

--- a/Resources/views/form/cookie_consent_theme.html.twig
+++ b/Resources/views/form/cookie_consent_theme.html.twig
@@ -1,12 +1,8 @@
-{% block choice_row %}
+{% block checkbox_row %}
     <div class="ch-cookie-consent__category">
         <div class="ch-cookie-consent__category-toggle">
-            {% for child in form %}
-                {% if not child.rendered %}
-                    {{- form_widget(child) -}}
-                    {{- form_label(child, null, {translation_domain: choice_translation_domain}) -}}
-                {% endif %}
-            {% endfor %}
+            {{ form_widget(form) }}
+            {{ form_label(form, null, {translation_domain: translation_domain}) }}
         </div>
         <div class="ch-cookie-consent__category-information">
             <h4 class="ch-cookie-consent__category-title">{{ ('ch_cookie_consent.'~name~'.title')|trans({}, 'CHCookieConsentBundle') }}</h4>


### PR DESCRIPTION
## Summary
- replace radio choices with `CheckboxType` switches in `CookieConsentType`
- adapt form theme to render checkbox fields
- adjust cookie consent CSS for switch styling

## Testing
- `php -l Form/CookieConsentType.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685559f7be68832a8241282432ea68d1